### PR TITLE
Fix RSPY_UAC_HOMEPAGE for osam

### DIFF
--- a/object_storage_access_manager/osam/main.py
+++ b/object_storage_access_manager/osam/main.py
@@ -18,6 +18,7 @@
 # a bash environment variable name, that is interpreted by the rs-server-fronted at startup.
 # Here we don't use the frontend so we need to replace it by its python value, read from its env var.
 # pylint: disable = wrong-import-order, wrong-import-position, ungrouped-imports
+# flake8: noqa: E402
 import os
 from importlib import reload
 

--- a/object_storage_access_manager/osam/main.py
+++ b/object_storage_access_manager/osam/main.py
@@ -13,11 +13,26 @@
 # limitations under the License.
 
 """osam main module."""
-# pylint: disable = wrong-import-order
+
+# Before any other imports, we need to override the uac (=apikey manager) homepage, that by default is set by
+# a bash environment variable name, that is interpreted by the rs-server-fronted at startup.
+# Here we don't use the frontend so we need to replace it by its python value, read from its env var.
+# pylint: disable = wrong-import-order, wrong-import-position, ungrouped-imports
+import os
+from importlib import reload
+
+from rs_server_common.authentication import apikey
+
+os.environ["APIKEY_DESCRIPTION"] = apikey.APIKEY_DESCRIPTION.replace(
+    "${RSPY_UAC_HOMEPAGE}",
+    os.getenv("RSPY_UAC_HOMEPAGE", ""),
+)
+reload(apikey)
+
+# Other imports
 import asyncio  # for handling asynchronous tasks
 import json
 import logging
-import os
 import threading
 from contextlib import asynccontextmanager
 from typing import Any

--- a/object_storage_access_manager/tests/test_authentication.py
+++ b/object_storage_access_manager/tests/test_authentication.py
@@ -19,8 +19,8 @@ from typing import cast
 import pytest
 from osam import main
 from pytest_httpx import HTTPXMock
-from rs_server_common.authentication import authentication
-from rs_server_common.authentication.apikey import APIKEY_HEADER, ttl_cache
+from rs_server_common.authentication import apikey, authentication
+from rs_server_common.authentication.apikey import APIKEY_HEADER
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.pytest.pytest_utils import mock_oauth2
 from rs_server_common.utils.utils2 import AuthInfo
@@ -100,7 +100,7 @@ async def test_endpoints_security(  # pylint: disable=too-many-locals
         monkeypatch.setenv("RSPY_UAC_CHECK_URL", RSPY_UAC_CHECK_URL)
 
         # With a valid api key in headers, the uac manager will give access to the endpoint
-        ttl_cache.clear()  # clear the cached response
+        apikey.ttl_cache.clear()  # clear the cached response
         httpx_mock.add_response(
             url=RSPY_UAC_CHECK_URL,
             match_headers={APIKEY_HEADER: VALID_APIKEY},
@@ -231,7 +231,7 @@ async def test_endpoint_roles(  # pylint: disable=too-many-arguments,too-many-lo
 
         # Mock the UAC response. Clear the cached response everytime.
         if test_apikey:
-            ttl_cache.clear()
+            apikey.ttl_cache.clear()
             httpx_mock.add_response(
                 url=RSPY_UAC_CHECK_URL,
                 match_headers={APIKEY_HEADER: VALID_APIKEY},


### PR DESCRIPTION
Fix the link "Authorize -> Create it from here" that is not working in osam:

<img width="1678" height="755" alt="image" src="https://github.com/user-attachments/assets/5fc02cfa-0036-4dc0-8bac-39cca8c4167a" />
